### PR TITLE
Use SWE-bench harness for real self-improvement evaluations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,15 @@ Run container: `docker run -it -v $(pwd):/app self-improve-agent`.
 ## Usage
 Self-improve and eval: `python src/self_improve.py --entry django__django-XXXX --model claude-3-5-sonnet-20240620`.
 Eval only: `python src/evaluate.py --patch_path model_patch.diff --model_name test_model`.
-Uses SWE-bench subsets (small/medium/big) for eval.
+Uses SWE-bench subsets (small/medium/big) for evaluation with the official harness.
 
 
 # The full pipeline involves:
 1. Baseline Evaluation (run_swe_eval in src/evaluate.py):
 
-- Creates an empty current_patch.diff to simulate a baseline.
-- Uses a Docker container (self-improve-agent image) to apply the patch.
-- Simulates SWE-bench evaluation for placeholder tasks (e.g., django__django-10973, django__django-11066).
-- Returns mock results (e.g., resolved: False for empty patches) saved in output/baseline/<model_name>_report.json.
+- Creates an empty `current_patch.diff` for the baseline run.
+- Invokes the SWE-bench evaluation harness on the first 10 instances listed in `small.json` (or other subset files).
+- Produces a real evaluation report saved under `output/<model_name>/`.
 
 
 2. Diagnosis (Agent.chat in src/agent.py):
@@ -33,6 +32,5 @@ Uses SWE-bench subsets (small/medium/big) for eval.
 
 4. Re-evaluation (run_swe_eval in src/evaluate.py):
 
-- Applies the new patch in a Docker container.
-- Re-runs the mock evaluation, producing results (e.g., resolved: True if the patch applies cleanly).
-- Saves results to output/improved/<model_name>_report.json and logs them.
+- Runs the harness again with the generated patch on the same SWE-bench instances.
+- Saves results to `output/<model_name>/` and logs them.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,5 @@ dependencies = [
   "gitpython",
   "openai",
   "datasets",
-  # uncomment if you want real SWE-bench harness inside the image
-  # "swebench",
+  "swebench",
 ]

--- a/src/self_improve.py
+++ b/src/self_improve.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import Optional
 from .utils import setup_docker, apply_patch, get_logs
 from .agent import Agent
 from .evaluate import run_swe_eval
@@ -28,7 +27,7 @@ def self_improve(entry: str, model: str) -> None:
     os.makedirs("output/baseline", exist_ok=True)
     with open("current_patch.diff", "w") as f:
         f.write("")  # Empty initial patch for baseline
-    eval_results = run_swe_eval("current_patch.diff", "baseline")
+    eval_results = run_swe_eval("current_patch.diff", "baseline", num_evals=10)
     logs = get_logs(eval_results)
 
     print("Logs: ", logs)
@@ -59,7 +58,7 @@ def self_improve(entry: str, model: str) -> None:
     container.remove()
 
     # Step 4: Re-eval
-    new_results = run_swe_eval("new_patch.diff", "improved")
+    new_results = run_swe_eval("new_patch.diff", "improved", num_evals=10)
     print(json.dumps(new_results, indent=2))
 
 


### PR DESCRIPTION
## Summary
- Replace mock evaluator with harness-backed `run_swe_eval` that reads subset files and calls the official SWE-bench evaluation
- Wire self-improvement loop to run baseline and improved patches against 10 SWE-bench tasks
- Document harness usage and add `swebench` dependency

## Testing
- `pytest`
- `python src/evaluate.py --patch_path current_patch.diff --model_name test_model --num_evals 1` *(fails: Couldn't reach 'SWE-bench/SWE-bench' on the Hub (ProxyError))*

------
https://chatgpt.com/codex/tasks/task_e_68b615593180832b91aad6eed05efea4